### PR TITLE
Fix for custom notifications not displayed

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -369,10 +369,11 @@ function ip_editor() {
 
                 <?php
                 $ip_upload_size = get_imagepress_option('ip_upload_size');
+                $ip_ezdz_label = get_imagepress_option('ip_ezdz_label');
                 $uploadsize = number_format((($ip_upload_size * 1024)/1024000), 0, '.', '');
                 $datauploadsize = $uploadsize * 1024000;
                 ?>
-                <p><label for="imagepress_image_file"><i class="fa fa-cloud-upload"></i> Replace main image (<?php echo $uploadsize . 'MB ' . __('maximum', 'imagepress'); ?>)...</label><br><input type="file" accept="image/*" data-max-size="<?php echo $datauploadsize; ?>" name="imagepress_image_file" id="imagepress_image_file"></p>
+                <p><label for="imagepress_image_file"><i class="fa fa-cloud-upload"></i> Replace main image (<?php echo $uploadsize . 'MB ' . __('maximum', 'imagepress'); ?>)...</label><br><input type="file" accept="image/*" data-max-size="<?php echo $datauploadsize; ?>" data-ezdz-label="<? echo $ip_ezdz_label;?>" name="imagepress_image_file" id="imagepress_image_file"></p>
 
                 <?php if(1 == get_imagepress_option('ip_upload_secondary')) { ?>
                     <hr>

--- a/modules/mod-notifications.php
+++ b/modules/mod-notifications.php
@@ -120,7 +120,7 @@ function imagepress_notifications($atts) {
         }
 
         // custom
-        if(0 == $line->postID || '-1' == $line->postID) {
+        if(0 == $line->userID || '-1' == $line->userID) {
             $display .= '<div class="notification-item n' . $line->ID . ' ' . $class . '" data-id="' . $line->ID . '"><i class="fa fa-fw ' . $line->actionIcon . '"></i> ' . $line->actionType . '<time>' . $time . '</time></div>';
         }
     }


### PR DESCRIPTION
Custom notifications come from userID 0... checking against postID doesn’t work - all notifications have a postID. Switch to $line->userID

Ref: https://github.com/getButterfly/imagepress/issues/69